### PR TITLE
Add SwiftUI mechanical calculator app

### DIFF
--- a/MechCalc/ContentView.swift
+++ b/MechCalc/ContentView.swift
@@ -1,0 +1,88 @@
+import SwiftUI
+
+struct ContentView: View {
+    enum SolveFor: String, CaseIterable, Identifiable {
+        case force = "Force (F)"
+        case mass = "Mass (m)"
+        case acceleration = "Acceleration (a)"
+        var id: String { self.rawValue }
+    }
+
+    @State private var solveFor: SolveFor = .force
+    @State private var force: String = ""
+    @State private var mass: String = ""
+    @State private var acceleration: String = ""
+    @State private var result: String = ""
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section(header: Text("Solve for")) {
+                    Picker("Variable", selection: $solveFor) {
+                        ForEach(SolveFor.allCases) { option in
+                            Text(option.rawValue).tag(option)
+                        }
+                    }
+                    .pickerStyle(SegmentedPickerStyle())
+                }
+
+                Section(header: Text("Inputs")) {
+                    if solveFor != .force {
+                        TextField("Force (N)", text: $force)
+                            .keyboardType(.decimalPad)
+                    }
+                    if solveFor != .mass {
+                        TextField("Mass (kg)", text: $mass)
+                            .keyboardType(.decimalPad)
+                    }
+                    if solveFor != .acceleration {
+                        TextField("Acceleration (m/s^2)", text: $acceleration)
+                            .keyboardType(.decimalPad)
+                    }
+                }
+
+                Button("Calculate") {
+                    calculate()
+                }
+                if !result.isEmpty {
+                    Section(header: Text("Result")) {
+                        Text(result)
+                    }
+                }
+            }
+            .navigationTitle("Mechanical Calc")
+        }
+    }
+
+    func calculate() {
+        switch solveFor {
+        case .force:
+            guard let m = Double(mass), let a = Double(acceleration) else {
+                result = "Invalid input"
+                return
+            }
+            let f = m * a
+            result = String(format: "Force = %.2f N", f)
+        case .mass:
+            guard let f = Double(force), let a = Double(acceleration), a != 0 else {
+                result = "Invalid input"
+                return
+            }
+            let m = f / a
+            result = String(format: "Mass = %.2f kg", m)
+        case .acceleration:
+            guard let f = Double(force), let m = Double(mass), m != 0 else {
+                result = "Invalid input"
+                return
+            }
+            let a = f / m
+            result = String(format: "Acceleration = %.2f m/s^2", a)
+        }
+    }
+}
+
+struct ContentView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentView()
+    }
+}

--- a/MechCalc/MechanicalCalculatorApp.swift
+++ b/MechCalc/MechanicalCalculatorApp.swift
@@ -1,0 +1,10 @@
+import SwiftUI
+
+@main
+struct MechanicalCalculatorApp: App {
+    var body: some Scene {
+        WindowGroup {
+            ContentView()
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# MechanicalCalculatorApp
+
+This is a simple SwiftUI iPhone application that lets you perform a basic mechanical engineering calculation using Newton's second law (`F = m * a`).
+
+## Features
+
+- Choose which variable to solve for: Force, Mass, or Acceleration.
+- Input the remaining two variables.
+- Tap **Calculate** to compute the missing value.
+
+## Building
+
+Open the `MechCalc` directory in Xcode as a new project (SwiftUI App template) and copy the files from this repository. Build and run on the iOS simulator or device.
+


### PR DESCRIPTION
## Summary
- add simple SwiftUI mechanical engineering calculator
- include instructions in README

## Testing
- `swiftc MechCalc/ContentView.swift MechCalc/MechanicalCalculatorApp.swift` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6864d67de9cc832d9b447341de01deb3